### PR TITLE
Use `from-referrer` to spawn a Gitpod workspace for a fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ The VNC support is inspired from the https://github.com/robotology/icub-gazebo-g
 ## Instructions  
 Click on the following badge to open the GitPod image:
 
-[![Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/traversaro/gitpod-ubuntu-20.04)
+[![Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer)


### PR DESCRIPTION
This way, clicking on the badge of a forked repo will spawn the correct Gitpod workspace.
It works only for public repos, but this is the case.